### PR TITLE
[RA-27] Omit newsilkroad From Test Coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ exclude=migrations
 
 [coverage:run]
 branch = true
-omit = */tests*, */migrations/*, .tox/*, manage.py
+omit = */tests*, */migrations/*, .tox/*, manage.py, newsilkroad/*
 source = .
 
 [coverage:report]


### PR DESCRIPTION
https://caktus.atlassian.net/browse/RA-27

I didn't find anything in the `newsilkroad` directory worth testing, so I omitted it from coverage.