### PR TITLE
Need to upgrade django-rq to get the arg parsing fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ django-picklefield==0.3.2
 django-polymorphic==1.0.2
 django-pylibmc==0.6.1
 django-reversion==2.0.6
-django-rq==0.9.2
+django-rq==0.9.5
 Django-Select2==5.8.6
 django-storages==1.5.1
 django-suit==0.2.21


### PR DESCRIPTION
This is currently failing to run in production with `error: unrecognized arguments: default`. This is an incompatibility with Django 1.10 and was fixed in 0.9.4. Once this has been tested on staging I'll merge into master and fix on production.