### PR TITLE
Fixing Deploy Errors Related to RA-35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,15 +52,19 @@ branches:
     - staging
 
 deploy:
-  provider: heroku
-  strategy: git
-  api_key:
-    secure: UVXjmii2d8zVB7guYehEtnUP2BpEqNPx0sYYSdmvOCopgucT4H3J/TiIKeEdbEEDUnnJPp1+BePfDSQ3t5P9VbodAbFDvKjH2Mc+fDfYB2zMWyJZeWnCPtnsMyVX5KpGlx75fEEAgIlFgdDX3Kci9706lDy+qXLARO9STgeLUtsWQv0rrmms3AGMfz86ZjjyXosH/5Zi9JR5UBm81UWaa3kgyFcyf0Y+ApItwJdGQ65nNqL6/NRumjGp71LMItzF53iIh9By3z/oF4w6zlHIdnrXZUfQdR1zg3ZmQcSPvtMNW93W9LmPzYZTdDpdnIMaEnrzLgEQkUvbYhxYSNJl2uqrZwH1v5nJE3b8mK1bFkEAXIT1yYlZiTojHjJkCOL9ElhgaX2fnaV5hC7qwUFvg1JOe8qW5jQjTMTqhq3432NAZUpMTMGrcGw/d6jVLIPhFhbhs56fiJGVCQAF0y4wwaJr8qJqjSCql6wBDuSvCy1YndpYcvkOkdENPGUOx/c6LUuw7M1tkCJZzirNteibsOUNae8t5XTA02LlvA53iuksEEnM8V8ZIk3TsZ2C/NZD7/f0wGJf83tvTAPd9o+E12h2Zui2rNz6PzzraA7SB0De123CMCNyBziRxd1Shkz+QjSHfp43ab0Mz6adAxtQpNJ10xGyztVae0P5iir7YA8=
-  app:
-    staging: csis-reconasia-bravo
-    master: csis-reconasia-alfa
-  run:
-    - restart
-  on:
-    - staging
-    - master
+  - provider: heroku
+    strategy: git
+    api_key:
+      secure: UVXjmii2d8zVB7guYehEtnUP2BpEqNPx0sYYSdmvOCopgucT4H3J/TiIKeEdbEEDUnnJPp1+BePfDSQ3t5P9VbodAbFDvKjH2Mc+fDfYB2zMWyJZeWnCPtnsMyVX5KpGlx75fEEAgIlFgdDX3Kci9706lDy+qXLARO9STgeLUtsWQv0rrmms3AGMfz86ZjjyXosH/5Zi9JR5UBm81UWaa3kgyFcyf0Y+ApItwJdGQ65nNqL6/NRumjGp71LMItzF53iIh9By3z/oF4w6zlHIdnrXZUfQdR1zg3ZmQcSPvtMNW93W9LmPzYZTdDpdnIMaEnrzLgEQkUvbYhxYSNJl2uqrZwH1v5nJE3b8mK1bFkEAXIT1yYlZiTojHjJkCOL9ElhgaX2fnaV5hC7qwUFvg1JOe8qW5jQjTMTqhq3432NAZUpMTMGrcGw/d6jVLIPhFhbhs56fiJGVCQAF0y4wwaJr8qJqjSCql6wBDuSvCy1YndpYcvkOkdENPGUOx/c6LUuw7M1tkCJZzirNteibsOUNae8t5XTA02LlvA53iuksEEnM8V8ZIk3TsZ2C/NZD7/f0wGJf83tvTAPd9o+E12h2Zui2rNz6PzzraA7SB0De123CMCNyBziRxd1Shkz+QjSHfp43ab0Mz6adAxtQpNJ10xGyztVae0P5iir7YA8=
+    app: csis-reconasia-bravo
+    run: restart
+    on:
+      branch: staging
+  - provider: heroku
+    strategy: git
+    api_key:
+      secure: UVXjmii2d8zVB7guYehEtnUP2BpEqNPx0sYYSdmvOCopgucT4H3J/TiIKeEdbEEDUnnJPp1+BePfDSQ3t5P9VbodAbFDvKjH2Mc+fDfYB2zMWyJZeWnCPtnsMyVX5KpGlx75fEEAgIlFgdDX3Kci9706lDy+qXLARO9STgeLUtsWQv0rrmms3AGMfz86ZjjyXosH/5Zi9JR5UBm81UWaa3kgyFcyf0Y+ApItwJdGQ65nNqL6/NRumjGp71LMItzF53iIh9By3z/oF4w6zlHIdnrXZUfQdR1zg3ZmQcSPvtMNW93W9LmPzYZTdDpdnIMaEnrzLgEQkUvbYhxYSNJl2uqrZwH1v5nJE3b8mK1bFkEAXIT1yYlZiTojHjJkCOL9ElhgaX2fnaV5hC7qwUFvg1JOe8qW5jQjTMTqhq3432NAZUpMTMGrcGw/d6jVLIPhFhbhs56fiJGVCQAF0y4wwaJr8qJqjSCql6wBDuSvCy1YndpYcvkOkdENPGUOx/c6LUuw7M1tkCJZzirNteibsOUNae8t5XTA02LlvA53iuksEEnM8V8ZIk3TsZ2C/NZD7/f0wGJf83tvTAPd9o+E12h2Zui2rNz6PzzraA7SB0De123CMCNyBziRxd1Shkz+QjSHfp43ab0Mz6adAxtQpNJ10xGyztVae0P5iir7YA8=
+    app: csis-reconasia-alfa
+    run: restart
+    on:
+      branch: master


### PR DESCRIPTION
TravisCI did not link the format of the changes adding the production deployment in #169. See https://travis-ci.org/CSIS-iLab/new-silk-road/builds/257749249. I've broken these out into two sections as recommended here https://stackoverflow.com/questions/39506192/travis-ci-deploy-different-branches-to-different-servers. `travis lint` no longer shows errors on the deploy section with this change.