### PR TITLE
[RA-33] Writings Tests

### DIFF
--- a/writings/admin.py
+++ b/writings/admin.py
@@ -123,7 +123,9 @@ class OrderedEntryInline(admin.StackedInline):
     )
 
     def entry_publication_date(self, instance):
-        return instance.entry.publication_date.strftime('%Y-%m-%d %H:%M:%S')
+        if instance.entry.publication_date:
+            return instance.entry.publication_date.strftime('%Y-%m-%d %H:%M:%S')
+        return None
     entry_publication_date.description = 'Publication Date'
 
     def entry_published(self, instance):

--- a/writings/apps.py
+++ b/writings/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class WritingsConfig(AppConfig):
-    name = 'writings'

--- a/writings/templates/writings/entry_detail.html
+++ b/writings/templates/writings/entry_detail.html
@@ -73,7 +73,7 @@
     {% endif %}
     <ul class="links clean">
         <li>
-            {% with object.get_previous_published_entry as entry %}{% if entry %}
+            {% with object.get_previous_published_entry as entry %}{% if entry and entry.is_visible %}
             <a href="{{entry.get_absolute_url}}">
                 <span class='action'>Previous</span>
                 <span class='title'>{{ entry.title|truncatechars:30 }}</span>
@@ -84,7 +84,7 @@
             {% endif %}{% endwith %}
         </li>
         <li>
-            {% with object.get_next_published_entry as entry %}{% if entry %}
+            {% with object.get_next_published_entry as entry %}{% if entry and entry.is_visible %}
             <a href="{{entry.get_absolute_url}}">
                 <span class='action'>Next</span>
                 <span class='title'>{{ entry.title|truncatechars:30 }}</span>

--- a/writings/tests/factories.py
+++ b/writings/tests/factories.py
@@ -1,6 +1,18 @@
-from django.utils.text import slugify
-import pytz
 import factory
+import pytz
+
+from django.utils.text import slugify
+
+
+class TagFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = 'taggit.Tag'
+
+    name = factory.Faker('text', max_nb_chars=100)
+
+    @factory.post_generation
+    def slug(self, create, extracted, **kwargs):
+        self.slug = slugify(self.name)
 
 
 class CategoryFactory(factory.django.DjangoModelFactory):
@@ -40,9 +52,20 @@ class EntryFactory(factory.django.DjangoModelFactory):
             return
 
         if extracted:
-            # A list of groups were passed in, use them
+            # A list of categories were passed in, use them
             for cat in extracted:
                 self.categories.add(cat)
+
+    @factory.post_generation
+    def tags(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of tags were passed in, use them
+            for cat in extracted:
+                self.tags.add(cat)
 
     @factory.post_generation
     def slug(self, create, extracted, **kwargs):

--- a/writings/tests/test_admin.py
+++ b/writings/tests/test_admin.py
@@ -1,0 +1,143 @@
+from unittest.mock import Mock
+
+from django.test import TestCase
+
+from .. import admin, models
+from . import factories
+
+
+class AdminActionsTestCase(TestCase):
+    """Admin actions to publish/unpublish."""
+
+    def setUp(self):
+        super().setUp()
+        self.modeladmin = Mock()
+        self.request = Mock()
+        self.entry = factories.EntryFactory(published=True)
+        self.other = factories.EntryFactory(published=True)
+        self.unpublished = factories.EntryFactory(published=False)
+
+    def test_publish_queryset(self):
+        """Mark a queryset as published."""
+
+        qs = models.Entry.objects.all()
+        admin.make_published_with_date(self.modeladmin, self.request, qs)
+        for entry in [self.entry, self.other, self.unpublished]:
+            entry.refresh_from_db()
+            with self.subTest():
+                self.assertTrue(entry.published)
+                self.assertIsNotNone(entry.publication_date)
+
+    def test_unpublish_queryset(self):
+        """Unpublish a set of objects."""
+
+        qs = models.Entry.objects.all()
+        admin.make_not_published_reset_date(self.modeladmin, self.request, qs)
+        for entry in [self.entry, self.other, self.unpublished]:
+            entry.refresh_from_db()
+            with self.subTest():
+                self.assertFalse(entry.published)
+                self.assertIsNone(entry.publication_date)
+
+
+class CategoryAdminTestCase(TestCase):
+    """Admin customizations for categories."""
+
+    def setUp(self):
+        super().setUp()
+        self.admin = admin.CategoryAdmin(models.Category, admin_site=Mock())
+
+    def test_entry_count(self):
+        """Display of the number of related entries."""
+
+        category = factories.CategoryFactory()
+        self.assertEqual(self.admin.entry_count(category), 0)
+        factories.EntryFactory(categories=[category, ])
+        self.assertEqual(self.admin.entry_count(category), 1)
+
+
+class EntryAdminTestCase(TestCase):
+    """Admin customizations for entries."""
+
+    def setUp(self):
+        super().setUp()
+        self.admin = admin.EntryAdmin(models.Entry, admin_site=Mock())
+        self.entry = factories.EntryFactory()
+
+    def test_categories(self):
+        """Display the related categories."""
+
+        self.assertHTMLEqual(self.admin.categories_display(self.entry), '<ul></ul>')
+        category = factories.CategoryFactory(name='Test')
+        self.entry.categories.add(category)
+        self.assertHTMLEqual(self.admin.categories_display(self.entry), '<ul><li>Test</li></ul>')
+
+    def test_page_link(self):
+        """Link to the public page for this entry."""
+
+        self.assertHTMLEqual(
+            self.admin.page_link(self.entry),
+            '<a href="{}" target="_blank">View on Site</a>'.format(self.entry.get_absolute_url()))
+
+    def test_is_visible(self):
+        """Indicator for whether the entry is visible to public vistors."""
+
+        self.entry.published = True
+        self.assertTrue(self.admin.page_is_visible(self.entry))
+        self.entry.published = False
+        self.assertFalse(self.admin.page_is_visible(self.entry))
+
+
+class OrderedEntryInlineTestCase(TestCase):
+    """Ordered entries for a given collection."""
+
+    def setUp(self):
+        super().setUp()
+        self.admin = admin.OrderedEntryInline(models.EntryCollection, admin_site=Mock())
+        self.collection = factories.EntryCollectionFactory()
+        self.entry = factories.EntryFactory()
+        self.entry_order = factories.OrderedEntryFactory(
+            entry=self.entry, collection=self.collection, order=1)
+
+    def test_entry_publication_date(self):
+        """Display the publication date of the related entry."""
+
+        self.assertEqual(
+            self.admin.entry_publication_date(self.entry_order),
+            self.entry.publication_date.strftime('%Y-%m-%d %H:%M:%S'))
+        self.entry_order.entry.publication_date = None
+        self.assertIsNone(self.admin.entry_publication_date(self.entry_order))
+
+    def test_entry_published(self):
+        """Display indication that the related entry is published."""
+
+        self.entry_order.entry.published = True
+        self.assertTrue(self.admin.entry_published(self.entry_order))
+        self.entry_order.entry.published = False
+        self.assertFalse(self.admin.entry_published(self.entry_order))
+
+    def test_entry_visible(self):
+        """Display indication that the related entry is visible."""
+
+        self.entry_order.entry.published = True
+        self.assertTrue(self.admin.entry_visible(self.entry_order))
+        self.entry_order.entry.published = False
+        self.assertFalse(self.admin.entry_visible(self.entry_order))
+
+
+class EntryCollectionAdminTestCase(TestCase):
+    """Customization of the entry collection in the admin."""
+
+    def setUp(self):
+        super().setUp()
+        self.admin = admin.EntryCollectionAdmin(models.EntryCollection, admin_site=Mock())
+
+    def test_entry_count(self):
+        """Display of the number of related entries."""
+
+        collection = factories.EntryCollectionFactory()
+        self.assertEqual(self.admin.entry_count(collection), 0)
+        entry = factories.EntryFactory()
+        factories.OrderedEntryFactory(
+            entry=entry, collection=collection, order=1)
+        self.assertEqual(self.admin.entry_count(collection), 1)

--- a/writings/tests/test_admin.py
+++ b/writings/tests/test_admin.py
@@ -54,6 +54,8 @@ class CategoryAdminTestCase(TestCase):
         self.assertEqual(self.admin.entry_count(category), 0)
         factories.EntryFactory(categories=[category, ])
         self.assertEqual(self.admin.entry_count(category), 1)
+        factories.EntryFactory(categories=[category, ], published=False)
+        self.assertEqual(self.admin.entry_count(category), 2)
 
 
 class EntryAdminTestCase(TestCase):
@@ -141,3 +143,7 @@ class EntryCollectionAdminTestCase(TestCase):
         factories.OrderedEntryFactory(
             entry=entry, collection=collection, order=1)
         self.assertEqual(self.admin.entry_count(collection), 1)
+        other = factories.EntryFactory(published=False)
+        factories.OrderedEntryFactory(
+            entry=other, collection=collection, order=2)
+        self.assertEqual(self.admin.entry_count(collection), 2)

--- a/writings/tests/test_models.py
+++ b/writings/tests/test_models.py
@@ -1,7 +1,8 @@
 import datetime
 
-from django.test import TestCase
 from django.db.utils import IntegrityError
+from django.test import TestCase
+from django.urls import reverse
 from django.utils.timezone import now
 
 from . import factories
@@ -25,7 +26,9 @@ class EntryTestCase(TestCase):
         """Entries should know their own URL."""
 
         entry = factories.EntryFactory(title='My Awesome Entry')
-        self.assertEqual(entry.get_absolute_url(), '/analysis/entries/my-awesome-entry/')
+        self.assertEqual(
+            entry.get_absolute_url(),
+            reverse('writings:entry-detail', kwargs={'slug': 'my-awesome-entry'}))
 
     def test_render_on_save(self):
         """Markdown should be rendered on save."""
@@ -111,6 +114,11 @@ class EntryCollectionTestCase(TestCase):
         obj = factories.CollectionWithSortedEntriesFactory.create()
         self.assertEqual(obj.entries.count(), 2)
 
+    def test_str(self):
+        """Collections are represented by their name."""
+        collection = factories.EntryCollectionFactory(name='My Collection')
+        self.assertEqual(str(collection), 'My Collection')
+
 
 class CategoryTestCase(TestCase):
 
@@ -118,7 +126,9 @@ class CategoryTestCase(TestCase):
         """Categories should know their own URL."""
 
         category = factories.CategoryFactory(name='Awesome', slug='awesome')
-        self.assertEqual(category.get_absolute_url(), '/analysis/categories/awesome/')
+        self.assertEqual(
+            category.get_absolute_url(),
+            reverse('writings:category-detail', kwargs={'slug': 'awesome'}))
 
     def test_str(self):
         """Categories are represented by their name."""

--- a/writings/tests/test_models.py
+++ b/writings/tests/test_models.py
@@ -1,38 +1,127 @@
+import datetime
+
 from django.test import TestCase
 from django.db.utils import IntegrityError
-from .factories import (
-    CategoryFactory,
-    EntryFactory,
-    EntryCollectionFactory,
-    OrderedEntryFactory,
-    CollectionWithSortedEntriesFactory,
-)
+from django.utils.timezone import now
+
+from . import factories
 
 
 class EntryTestCase(TestCase):
 
     def test_entry_auto_publication_date(self):
-        obj = EntryFactory.create(published=True)
+        """Publication date should be set on save."""
 
+        obj = factories.EntryFactory(published=True, publication_date=None)
         self.assertIsNotNone(obj.publication_date)
 
     def test_entry_categories(self):
-        CategoryFactory.create_batch(4)
-        obj = EntryFactory.create(categories=CategoryFactory.create_batch(2))
+        factories.CategoryFactory.create_batch(4)
+        obj = factories.EntryFactory.create(categories=factories.CategoryFactory.create_batch(2))
 
         self.assertEqual(obj.categories.count(), 2)
+
+    def test_url(self):
+        """Entries should know their own URL."""
+
+        entry = factories.EntryFactory(title='My Awesome Entry')
+        self.assertEqual(entry.get_absolute_url(), '/analysis/entries/my-awesome-entry/')
+
+    def test_render_on_save(self):
+        """Markdown should be rendered on save."""
+
+        entry = factories.EntryFactory(content='**bold**', description='*blip*')
+        self.assertHTMLEqual(entry.content_rendered, '<p><strong>bold</strong></p>')
+        self.assertHTMLEqual(entry.description_rendered, '<p><em>blip</em></p>')
+
+    def test_is_visible(self):
+        """Only currently published entries are considered visible."""
+
+        entry = factories.EntryFactory(published=True)
+        with self.subTest('Current entry'):
+            self.assertTrue(entry.is_visible())
+
+        with self.subTest('Not published'):
+            entry.published = False
+            self.assertFalse(entry.is_visible())
+
+        with self.subTest('Future entry'):
+            entry.published = True
+            entry.publication_date = now() + datetime.timedelta(days=7)
+            self.assertFalse(entry.is_visible())
+
+    def test_get_next(self):
+        """Return the next entry by published date. Entry itself might not be visible."""
+
+        today = now()
+        earlier = now() - datetime.timedelta(hours=1)
+        yesterday = now() - datetime.timedelta(days=1)
+        tomorrow = now() + datetime.timedelta(days=1)
+
+        unpublished_entry = factories.EntryFactory(published=False, publication_date=None)
+        latest_entry = factories.EntryFactory(published=True, publication_date=today)
+        earlier_entry = factories.EntryFactory(published=True, publication_date=earlier)
+        previous_entry = factories.EntryFactory(published=True, publication_date=yesterday)
+        future_entry = factories.EntryFactory(published=True, publication_date=tomorrow)
+
+        with self.subTest('Valid next entry'):
+            self.assertEqual(previous_entry.get_next_published_entry(), earlier_entry)
+            self.assertEqual(earlier_entry.get_next_published_entry(), latest_entry)
+            self.assertEqual(latest_entry.get_next_published_entry(), future_entry)
+
+        with self.subTest('No next entry'):
+            self.assertIsNone(unpublished_entry.get_next_published_entry())
+            self.assertIsNone(future_entry.get_next_published_entry())
+
+    def test_get_prev(self):
+        """Return the previous entry by published date. Entry itself might not be visible."""
+
+        today = now()
+        earlier = now() - datetime.timedelta(hours=1)
+        yesterday = now() - datetime.timedelta(days=1)
+        tomorrow = now() + datetime.timedelta(days=1)
+
+        unpublished_entry = factories.EntryFactory(published=False, publication_date=None)
+        latest_entry = factories.EntryFactory(published=True, publication_date=today)
+        earlier_entry = factories.EntryFactory(published=True, publication_date=earlier)
+        previous_entry = factories.EntryFactory(published=True, publication_date=yesterday)
+        future_entry = factories.EntryFactory(published=True, publication_date=tomorrow)
+
+        with self.subTest('Valid previous entry'):
+            self.assertEqual(future_entry.get_previous_published_entry(), latest_entry)
+            self.assertEqual(latest_entry.get_previous_published_entry(), earlier_entry)
+            self.assertEqual(earlier_entry.get_previous_published_entry(), previous_entry)
+
+        with self.subTest('No previous entry'):
+            self.assertIsNone(unpublished_entry.get_previous_published_entry())
+            self.assertIsNone(previous_entry.get_previous_published_entry())
 
 
 class EntryCollectionTestCase(TestCase):
 
     def test_entrycollection_fails_with_duplicate_entry(self):
         """The same entry cannot be in the same collection more than once."""
-        collection = EntryCollectionFactory()
-        entry = EntryFactory()
-        OrderedEntryFactory(collection=collection, entry=entry)
+        collection = factories.EntryCollectionFactory()
+        entry = factories.EntryFactory()
+        factories.OrderedEntryFactory(collection=collection, entry=entry)
         with self.assertRaises(IntegrityError):
-            OrderedEntryFactory(collection=collection, entry=entry)
+            factories.OrderedEntryFactory(collection=collection, entry=entry)
 
     def test_entrycollection_succeeds_with_different_order(self):
-        obj = CollectionWithSortedEntriesFactory.create()
+        obj = factories.CollectionWithSortedEntriesFactory.create()
         self.assertEqual(obj.entries.count(), 2)
+
+
+class CategoryTestCase(TestCase):
+
+    def test_url(self):
+        """Categories should know their own URL."""
+
+        category = factories.CategoryFactory(name='Awesome', slug='awesome')
+        self.assertEqual(category.get_absolute_url(), '/analysis/categories/awesome/')
+
+    def test_str(self):
+        """Categories are represented by their name."""
+
+        category = factories.CategoryFactory(name='Awesome', slug='awesome')
+        self.assertEqual(str(category), 'Awesome')

--- a/writings/tests/test_views.py
+++ b/writings/tests/test_views.py
@@ -1,27 +1,29 @@
+import pytz
+
 from django.contrib.auth.models import AnonymousUser, User
 from django.http import Http404
 from django.test import TestCase, RequestFactory
-from .factories import (
-    # CategoryFactory,
-    EntryFactory,
-)
-from writings.views import (
-    EntryDetailView,
-)
+from django.urls import reverse
+from django.utils.timezone import now
 from faker import Faker
-import pytz
+
+from ..views import EntryDetailView
+from . import factories
 
 
 class EntryDetailViewTestCase(TestCase):
+
     def setUp(self):
         self.factory = RequestFactory()
         self.fake = Faker()
 
     def test_future_publication_date_hidden_to_anonymous_users(self):
-        '''Anonymous users should *not* see Entries whose published=True but have a publication_date set in the future.'''
-        obj = EntryFactory.create(
+        """Anonymous users should *not* see published Entries with a date set in the future."""
+
+        obj = factories.EntryFactory.create(
             published=True,
-            publication_date=self.fake.date_time_this_year(before_now=False, after_now=True, tzinfo=pytz.utc)
+            publication_date=self.fake.date_time_this_year(
+                before_now=False, after_now=True, tzinfo=pytz.utc)
         )
 
         request = self.factory.get(obj.get_absolute_url())
@@ -32,10 +34,12 @@ class EntryDetailViewTestCase(TestCase):
             self.assertEqual(response.status_code, 404)
 
     def test_future_publication_date_shown_to_authorized_users(self):
-        '''Authorized users should see Entries whose published=True but have a publication_date set in the future.'''
-        obj = EntryFactory.create(
+        """Authorized users should see published Entries with a date set in the future."""
+
+        obj = factories.EntryFactory.create(
             published=True,
-            publication_date=self.fake.date_time_this_year(before_now=False, after_now=True, tzinfo=pytz.utc)
+            publication_date=self.fake.date_time_this_year(
+                before_now=False, after_now=True, tzinfo=pytz.utc)
         )
 
         request = self.factory.get(obj.get_absolute_url())
@@ -44,3 +48,275 @@ class EntryDetailViewTestCase(TestCase):
 
         response = EntryDetailView.as_view()(request, slug=obj.slug)
         self.assertEqual(response.status_code, 200)
+
+
+class EntryListViewTestCase(TestCase):
+    """Listing published entries."""
+
+    @classmethod
+    def setUpTestData(cls):  # noqa
+        super().setUpTestData()
+        fake = Faker()
+        cls.entry = factories.EntryFactory(published=True)
+        cls.unpublished = factories.EntryFactory(published=False)
+        cls.future = factories.EntryFactory(
+            published=True, publication_date=fake.date_time_this_year(
+                before_now=False, after_now=True, tzinfo=pytz.utc))
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('writings:entry-list')
+
+    def test_get_page(self):
+        """Render the page to see all visible entries."""
+
+        with self.assertTemplateUsed('writings/entry_list.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, self.entry.get_absolute_url())
+            self.assertNotContains(response, self.unpublished.get_absolute_url())
+            self.assertNotContains(response, self.future.get_absolute_url())
+
+    def test_authorized_user(self):
+        """Authorized users can see unpublished and future entries on this page."""
+
+        User.objects.create_user(
+            username='jacob', email='jacob@fake.email', password='top_secret')
+        self.client.login(username='jacob', password='top_secret')
+
+        with self.assertTemplateUsed('writings/entry_list.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, self.entry.get_absolute_url())
+            self.assertContains(response, self.unpublished.get_absolute_url())
+            self.assertContains(response, self.future.get_absolute_url())
+
+
+class EntryCategoryListViewTestCase(TestCase):
+    """List entries in a given category."""
+
+    @classmethod
+    def setUpTestData(cls):  # noqa
+        super().setUpTestData()
+        fake = Faker()
+        cls.category = factories.CategoryFactory()
+        cls.entry = factories.EntryFactory(published=True, categories=[cls.category, ])
+        cls.other = factories.EntryFactory(published=True)
+        cls.unpublished = factories.EntryFactory(published=False, categories=[cls.category, ])
+        cls.future = factories.EntryFactory(
+            published=True, publication_date=fake.date_time_this_year(
+                before_now=False, after_now=True, tzinfo=pytz.utc), categories=[cls.category, ])
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('writings:category-detail', kwargs={'slug': self.category.slug})
+
+    def test_get_page(self):
+        """Render the page to see all visible entries."""
+
+        with self.assertTemplateUsed('writings/entry_category_list.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.context['category'], self.category)
+            self.assertContains(response, self.entry.get_absolute_url())
+            self.assertNotContains(response, self.other.get_absolute_url())
+            self.assertNotContains(response, self.unpublished.get_absolute_url())
+            self.assertNotContains(response, self.future.get_absolute_url())
+
+    def test_authorized_user(self):
+        """Authorized users can see unpublished and future entries on this page."""
+
+        User.objects.create_user(
+            username='jacob', email='jacob@fake.email', password='top_secret')
+        self.client.login(username='jacob', password='top_secret')
+
+        with self.assertTemplateUsed('writings/entry_category_list.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, self.entry.get_absolute_url())
+            self.assertNotContains(response, self.other.get_absolute_url())
+            self.assertContains(response, self.unpublished.get_absolute_url())
+            self.assertContains(response, self.future.get_absolute_url())
+
+    def test_unknown_category(self):
+        """Unknown category slug should return a 404."""
+
+        url = reverse('writings:category-detail', kwargs={'slug': 'does-not-exist'})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+
+class EntryTagListViewTestCase(TestCase):
+    """List entries with a given tag."""
+
+    @classmethod
+    def setUpTestData(cls):  # noqa
+        super().setUpTestData()
+        fake = Faker()
+        cls.tag = factories.TagFactory()
+        cls.entry = factories.EntryFactory(published=True, tags=[cls.tag, ])
+        cls.other = factories.EntryFactory(published=True)
+        cls.unpublished = factories.EntryFactory(published=False, tags=[cls.tag, ])
+        cls.future = factories.EntryFactory(
+            published=True, publication_date=fake.date_time_this_year(
+                before_now=False, after_now=True, tzinfo=pytz.utc), tags=[cls.tag, ])
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('writings:entry-tag-list', kwargs={'slug': self.tag.slug})
+
+    def test_get_page(self):
+        """Render the page to see all visible entries."""
+
+        with self.assertTemplateUsed('writings/entry_tag_list.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.context['tag'], self.tag)
+            self.assertContains(response, self.entry.get_absolute_url())
+            self.assertNotContains(response, self.other.get_absolute_url())
+            self.assertNotContains(response, self.unpublished.get_absolute_url())
+            self.assertNotContains(response, self.future.get_absolute_url())
+
+    def test_authorized_user(self):
+        """Authorized users can see unpublished and future entries on this page."""
+
+        User.objects.create_user(
+            username='jacob', email='jacob@fake.email', password='top_secret')
+        self.client.login(username='jacob', password='top_secret')
+
+        with self.assertTemplateUsed('writings/entry_tag_list.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, self.entry.get_absolute_url())
+            self.assertNotContains(response, self.other.get_absolute_url())
+            self.assertContains(response, self.unpublished.get_absolute_url())
+            self.assertContains(response, self.future.get_absolute_url())
+
+    def test_unknown_category(self):
+        """Unknown tag slug should return a 404."""
+
+        url = reverse('writings:entry-tag-list', kwargs={'slug': 'does-not-exist'})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+
+class CategoriesListViewTestCase(TestCase):
+    """Show available entry categories."""
+
+    @classmethod
+    def setUpTestData(cls):  # noqa
+        super().setUpTestData()
+        cls.category = factories.CategoryFactory()
+        cls.other = factories.CategoryFactory()
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('writings:category-list')
+
+    def test_get_page(self):
+        """Render the page to see all categories."""
+
+        with self.assertTemplateUsed('writings/category_list.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, self.category.get_absolute_url())
+            self.assertContains(response, self.other.get_absolute_url())
+
+
+class AnalysisHomeViewTestCase(TestCase):
+    """Show homepage with feature entries."""
+
+    def setUp(self):
+        super().setUp()
+        self.url = reverse('writings:home')
+        self.featured_category = factories.CategoryFactory(name='News', slug='news')
+        self.featured_entry_collection = factories.EntryCollectionFactory(
+            name='Analysis Page Featured Analysis', slug='analysis-page-featured-analysis')
+        self.featured_analyses_collection = factories.EntryCollectionFactory(
+            name='Analyses Featured', slug='analyses-featured')
+
+    def test_get_empty(self):
+        """Get page with no featured articles or existing entries."""
+
+        self.featured_category.delete()
+        self.featured_entry_collection.delete()
+        self.featured_analyses_collection.delete()
+
+        with self.assertTemplateUsed('writings/home.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertNotIn('highlighted_entry', response.context)
+            self.assertNotIn('highlighted_category', response.context)
+            self.assertNotIn('featured_entry', response.context)
+            self.assertIsNone(response.context['featured_analyses'])
+
+    def test_recent_entries(self):
+        """Page should include the most recent two published entries."""
+
+        entry = factories.EntryFactory(published=True)
+        other = factories.EntryFactory(published=True)
+
+        with self.assertTemplateUsed('writings/home.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.context['recent_entries']), 2)
+            self.assertIn(entry, response.context['recent_entries'])
+            self.assertIn(other, response.context['recent_entries'])
+            self.assertContains(response, entry.get_absolute_url())
+            self.assertContains(response, other.get_absolute_url())
+
+    def test_highlighted_category(self):
+        """The most recent entry from the featured category should be highlighted."""
+
+        factories.EntryFactory(
+            published=True, publication_date=now(),
+            categories=[self.featured_category, ])
+        factories.EntryFactory(
+            published=True, publication_date=now(),
+            categories=[self.featured_category, ])
+        last = factories.EntryFactory(
+            published=True, publication_date=now(),
+            categories=[self.featured_category, ])
+
+        with self.assertTemplateUsed('writings/home.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.context['highlighted_entry'], last)
+            self.assertEqual(response.context['highlighted_category'], self.featured_category)
+
+    def test_featured_entry(self):
+        """The most recent entry from the featured collection should be hightlighted.
+
+        This is used as the top level quote on the page.
+        """
+
+        entry = factories.EntryFactory(published=True, publication_date=now(), description='Here!')
+        other = factories.EntryFactory(published=True, publication_date=now())
+        factories.OrderedEntryFactory(
+            entry=entry, collection=self.featured_entry_collection, order=1)
+        factories.OrderedEntryFactory(
+            entry=other, collection=self.featured_entry_collection, order=2)
+
+        with self.assertTemplateUsed('writings/home.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.context['featured_entry'], entry)
+            self.assertContains(response, 'Here!')
+
+    def test_featured_analyses(self):
+        """Featured analyses should be included in the template."""
+
+        entry = factories.EntryFactory(published=True, publication_date=now(), description='Here!')
+        other = factories.EntryFactory(published=True, publication_date=now())
+        factories.OrderedEntryFactory(
+            entry=entry, collection=self.featured_analyses_collection, order=1)
+        factories.OrderedEntryFactory(
+            entry=other, collection=self.featured_analyses_collection, order=2)
+
+        with self.assertTemplateUsed('writings/home.html'):
+            response = self.client.get(self.url)
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(entry, response.context['featured_analyses'])
+            self.assertIn(other, response.context['featured_analyses'])
+            self.assertContains(response, entry.get_absolute_url())
+            self.assertContains(response, other.get_absolute_url())

--- a/writings/views.py
+++ b/writings/views.py
@@ -30,7 +30,7 @@ class ConfiguredCollectionMixin(ContextMixin):
     collection_limit = None
 
     def get_config_key(self):
-        if not self.config_key:
+        if not self.config_key:  # pragma: no cover
             raise AttributeError('ConfiguredCollectionMixin must define config_key property or override get_config_key method')
         return self.config_key
 
@@ -39,12 +39,12 @@ class ConfiguredCollectionMixin(ContextMixin):
         return getattr(config, config_key, None)
 
     def get_context_label(self):
-        if not self.context_label:
+        if not self.context_label:  # pragma: no cover
             raise AttributeError('ConfiguredCollectionMixin must define context_label property or override get_context_label method')
         return self.context_label
 
     def get_collection_limit(self):
-        if not isinstance(self.collection_limit, int):
+        if not isinstance(self.collection_limit, int):  # pragma: no cover
             raise AttributeError('ConfiguredCollectionMixin collection_limit must be an integer')
         return self.collection_limit
 
@@ -78,7 +78,7 @@ class FeaturedEntryMixin(FeaturedAnalysesMixin):
     featured_config_key = None
 
     def get_featured_config_key(self):
-        if not self.featured_config_key:
+        if not self.featured_config_key:  # pragma: no cover
             raise AttributeError('CollectionFeaturedEntryMixin must define featured_config_key property or override get_featured_config_key method')
         return self.featured_config_key
 


### PR DESCRIPTION
Testing for the `writings` app. Excluded a few branches from coverage which shouldn't execute while running the site. There are there to catch developer errors/misconfigurations.