### PR TITLE
[TRH-2939] Perfromance of the Centroid API

### DIFF
--- a/api/serializers/locations.py
+++ b/api/serializers/locations.py
@@ -92,11 +92,10 @@ class GeometryStoreCentroidSerializer(GeoFeatureModelSerializer):
         id_field = 'identifier'
 
     def get_properties(self, instance, fields):
-        project = Project.objects.filter(geo=instance)\
-                         .select_related('infrastructure_type')\
-                         .only('name', 'alternate_name', 'infrastructure_type__name').first()
-        infra_name = project.infrastructure_type.name if project and project.infrastructure_type else None
-        proj_name = project.alternate_name or project.name if project else None
+        # This makes use of the project_name, project_type, and project_alt_name
+        # annotations provided by the view for performance
+        proj_name = getattr(instance, 'project_alt_name') or instance.project_name or None
+        infra_name = instance.project_type or None
         icon_type = ICON_MAP.get(infra_name.lower(), 'dot') if infra_name else None
         return {
             'label': proj_name,

--- a/api/tests.py
+++ b/api/tests.py
@@ -137,9 +137,17 @@ class TestGeometryStoreCentroidViewSet(TestCase):
 
     def test_centroid_list(self):
 
-        # Make a GeometryStore object without points/lines/polygons/centroid; should not appear in list
+        # Make a GeometryStore object without points/lines/polygons/centroid
+        # This hould not appear in list
         unlocated = GeometryStore()
         unlocated.save()
+        # Single point store which doesn't have an associcated project
+        # This hould not appear in list
+        random_point = GeometryStore()
+        random_point.save()
+        point = PointGeometry(geom=Point(20, 30))
+        point.save()
+        random_point.points.add(point)
 
         with self.settings(PUBLISH_FILTER_ENABLED=True):
             with self.subTest('Authenticated and PUBLISH_FILTER_ENABLED'):
@@ -174,6 +182,69 @@ class TestGeometryStoreCentroidViewSet(TestCase):
                 # Both geometries from setUp should be in the list, but not the one without a centroid.
                 data = json.loads(response.content.decode())
                 self.assertEqual(len(data['features']), 2)
+
+    def test_response_format(self):
+        """Centroids should include related project information in their properties."""
+
+        with self.settings(PUBLISH_FILTER_ENABLED=True):
+            self.client.logout()
+            response = self.client.get(self.list_url)
+        self.assertEqual(response.status_code, 200)
+        # Only the geometry with a published project should be included.
+        data = json.loads(response.content.decode())
+        self.assertEqual(len(data['features']), 1)
+        feature = data['features'][0]
+        self.assertEqual(feature, {
+            'id': str(self.geom_with_published_project.identifier),
+            'type': 'Feature',
+            'geometry': {
+                'type': 'Point',
+                'coordinates': [
+                    self.geom_with_published_project.centroid.x,
+                    self.geom_with_published_project.centroid.y,
+                ],
+            },
+            'properties': {
+                'label': self.published_project.name,
+                'geostore': str(self.geom_with_published_project.identifier),
+                'icon-image': 'dot',
+                'infrastructureType': self.published_project.infrastructure_type.name,
+            }
+        })
+
+    def test_performance(self):
+        """Count the number of queries required to fetch the centroids."""
+
+        # Make a GeometryStore object without points/lines/polygons/centroid
+        # This hould not appear in list
+        unlocated = GeometryStore()
+        unlocated.save()
+        # Single point store which doesn't have an associcated project
+        # This hould not appear in list
+        random_point = GeometryStore()
+        random_point.save()
+        point = PointGeometry(geom=Point(20, 30))
+        point.save()
+        random_point.points.add(point)
+        # Create 9 more (for a total of 10) random point projects for the map
+        for i in range(9):
+            geo = GeometryStore()
+            geo.save()
+            point = PointGeometry(geom=Point(20, 30))
+            point.save()
+            geo.points.add(point)
+            project = ProjectFactory(published=True)
+            project.geo = geo
+            project.save()
+
+        with self.settings(PUBLISH_FILTER_ENABLED=True):
+            self.client.logout()
+            with self.assertNumQueries(1):
+                # All response data should be fetched in a single query
+                response = self.client.get(self.list_url)
+                self.assertEqual(response.status_code, 200)
+            data = json.loads(response.content.decode())
+            self.assertEqual(len(data['features']), 10)
 
 
 class TestOrganizationViewSet(TestCase):


### PR DESCRIPTION
This change uses annotations to remove the N queries required to include project data in the centriod API. Previously this required an additional query per geostore result to include the related project information. This is now fetched in a single query which greatly improves the performance. Locally this reduces the time from ~4.5 sec to ~200 ms.