### PR TITLE
[TRH-2954] Fix Organziation Filtering

### DIFF
--- a/api/filters/infrastructure.py
+++ b/api/filters/infrastructure.py
@@ -25,6 +25,7 @@ class InfrastructureTypeFilter(filters.FilterSet):
 
 class InitiativeFilter(filters.FilterSet):
     name = filters.AllLookupsFilter(field_name='name')
+    isnull = filters.BooleanFilter(field_name='pk', lookup_expr='isnull')
 
     geographic_scope = filters.RelatedFilter(
         'api.filters.locations.RegionFilter',

--- a/api/tests.py
+++ b/api/tests.py
@@ -325,6 +325,15 @@ class TestOrganizationViewSet(TestCase):
             self.assertIn(included_org.name, returned_orgs)
             self.assertNotIn(excluded_org.name, returned_orgs)
 
+        with self.subTest('filter by principal initiative existance'):
+            params = {
+                'principal_initiatives__isnull': 'False'
+            }
+            response = self.client.get(self.url, params)
+            returned_orgs = [result['name'] for result in json.loads(response.content.decode())['results']]
+            self.assertIn(included_org.name, returned_orgs)
+            self.assertNotIn(excluded_org.name, returned_orgs)
+
 
 class TestProjectViewSet(TestCase):
     def setUp(self):


### PR DESCRIPTION
The update of `djangorestframework-filters` broke the `/api/organizations/?principal_initiatives__isnull=False` filter used by the map for populating the options for filtering. I tried using `lookups='__all__'` as described by the docs but it wasn't working so I worked around it instead.