### PR TITLE
[TRH-2966] Saving Project Funding In Admin

### DIFF
--- a/infrastructure/forms.py
+++ b/infrastructure/forms.py
@@ -111,7 +111,7 @@ class ProjectFundingForm(forms.ModelForm):
     project = forms.ModelChoiceField(
         queryset=Project.objects.all(),
         widget=NameSearchWidget(model=Project),
-        required=False
+        required=True
     )
 
     class Meta:


### PR DESCRIPTION
https://caktus.atlassian.net/browse/TRH-2966

This error was happening when the admin user tried to save a `ProjectFunding` instance without a `Project` in the admin. Looking at the models, `ProjectFunding` requires a relationship to a `Project`, and the 1297 `ProjectFunding` instances in the database all contain a relationship to a `Project`. The fix here is to make `ProjectFundingForm.project` a required field. Since this form is only used in one place, it doesn’t seem like it will have unintended consequences.