### PR TITLE
[TRH-2937] Removing Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ botocore==1.10.4
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
-contextlib2==0.5.5
 croniter==0.3.20
 dj-database-url==0.5.0
 Django==1.11.12
@@ -39,12 +38,10 @@ elasticsearch==2.4.1
 elasticsearch-dsl==2.2.0
 html5lib==1.0.1
 idna==2.6
-IPy==0.83
 iso3166==0.8
 iso4217==1.5.20180101
 jmespath==0.9.3
 Markdown==2.6.11
-olefile==0.45.1
 Pillow==5.1.0
 psycopg2-binary==2.7.4
 pylibmc==1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bleach==2.1.3
-boto3==1.7.4
-botocore==1.10.4
+boto3==1.7.5
+botocore==1.10.5
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
@@ -17,7 +17,7 @@ django-heroku-memcacheify==1.0.0
 django-leaflet==0.23.0
 django_markymark==1.1.0
 django-mptt==0.9.0
-  django-js-asset==1.0.0
+  django-js-asset==1.1.0
 django-picklefield==1.0.0
 django-polymorphic==2.0.2
 django-pylibmc==0.6.1


### PR DESCRIPTION
Not many to remove but a few that don't appear to be needed. Assuming `olefile` was used a part of the earlier parsing/import work. `ipy` was required by django-maintenance` mode which has been removed. A few more version bumps as well.