### PR TITLE
Upgrade To Django 1.11.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chardet==3.0.4
 click==6.7
 croniter==0.3.20
 dj-database-url==0.5.0
-Django==1.11.12
+Django==1.11.15
 django-appconf==1.0.2
 django-cachalot==1.5.0
 django-constance[database]==2.2.0


### PR DESCRIPTION
This pull request upgrades Django from `1.11.12` to `1.11.15`, mainly to take advantage of the [most recently Django security patch](https://docs.djangoproject.com/en/2.1/releases/1.11.15/) that fixes a vulnerability for sites that use `settings.APPEND_SLASH` to automatically add a `/` to the end of URLs.