### PR TITLE
Increase API Pagination To 75

### DIFF
--- a/api/pagination.py
+++ b/api/pagination.py
@@ -2,5 +2,5 @@ from rest_framework.pagination import LimitOffsetPagination
 
 
 class ApiPagination(LimitOffsetPagination):
-    default_limit = 50
+    default_limit = 75
     max_limit = 200


### PR DESCRIPTION
This pull request increases the default API pagination from 50 to 75.