### PR TITLE
Added powerplant to ICON_MAP in locations

### DIFF
--- a/api/serializers/locations.py
+++ b/api/serializers/locations.py
@@ -18,7 +18,8 @@ ICON_MAP = {
     "rail": "Rail",
     "road": "Road",
     "multimodal": "Dryport",
-    "intermodal": "Dryport"
+    "intermodal": "Dryport",
+    "powerplant": "Powerplant",
 }
 
 

--- a/website/assets/apps/megamap/helpers/GeoStyles.js
+++ b/website/assets/apps/megamap/helpers/GeoStyles.js
@@ -79,7 +79,7 @@ export default class GeoStyles {
           },
         }),
       },
-      'power-plant': {
+      powerplant: {
         points: objectMerge(pointStyle, {
           layout: {
             'icon-image': {


### PR DESCRIPTION
Because we are using the names from InfrastuctureTypes in labeling the different layers, I changed `Power Plant` to `Powerplant` in the admin.  This will need to happen in the staging admin for this implementation to work.  