### PR TITLE
Fix PowerPlant Admin Timeout

### DIFF
--- a/infrastructure/admin.py
+++ b/infrastructure/admin.py
@@ -55,6 +55,7 @@ class ProjectsInitiativeInline(admin.StackedInline):
 class ProjectsOwnersInline(admin.StackedInline):
     model = OwnerStake
     form = ProjectOwnerStakeForm
+    raw_id_fields = ('owner',)
 
     class Media:
         css = {
@@ -369,4 +370,3 @@ class CuratedProjectCollectionAdmin(admin.ModelAdmin):
         'published',
     )
     filter_horizontal = ('projects', )
-

--- a/infrastructure/forms.py
+++ b/infrastructure/forms.py
@@ -152,6 +152,11 @@ class PowerPlantForm(forms.ModelForm):
     plant_day_online = DayField(required=False)
     decommissioning_month = MonthField(required=False)
     decommissioning_day = DayField(required=False)
+    geo = GeometrySearchField(
+        required=False,
+        queryset=GeometryStore.objects.all(),
+        help_text=GeometrySearchField.help_text
+    )
 
     class Meta:
         model = PowerPlant


### PR DESCRIPTION
This pull request fixes an admin timeout on the `PowerPlant` admin detail page:
 - the `geo` options now load using a `GeometrySearchField`, like on the `Project` admin detail page
 - the `ProjectsOwnersInline` now has a raw id field for `owner`, instead of loading each of the `Organization`s as an `<option>` in the DOM