### PR TITLE
Use Dryport Icon Image For Intermodals

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -166,7 +166,7 @@ class GeometryStoreCentroidViewSet(viewsets.ReadOnlyModelViewSet):
                 When(project_type_lower='rail', then=Value('Rail')),
                 When(project_type_lower='road', then=Value('Road')),
                 When(project_type_lower='multimodal', then=Value('Multimodal')),
-                When(project_type_lower='intermodal', then=Value('Intermodal')),
+                When(project_type_lower='intermodal', then=Value('Dryport')),
                 When(project_type_lower='powerplant', then=Value('Powerplant')),
                 default=Value('dot'),
                 output_field=CharField(),


### PR DESCRIPTION
In pull request #243, a database annotation was added that causes the `/api/geostore-centroids/` API endpoint to return the `icon-image` based on the infrastructure type. For intermodals, this value is set to `"Intermodal"`, but this causes an issue, because there is no instermodal later. Instead, this pull request returns a value of `"Dryport"` for intermodals.