### PR TITLE
admin select2 errors

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.postgres.aggregates import StringAgg
 from django.db.models import Case, CharField, Count, F, Value, When
 from django.db.models.functions import Lower
+from django.utils.cache import add_never_cache_headers
 
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets, generics
@@ -205,6 +206,12 @@ class GeometryStoreCentroidViewSet(viewsets.ReadOnlyModelViewSet):
 
         return queryset
 
+    def list(self, request, *args, **kwargs):
+        "Don't cache powerplant API response since it's >1MB"
+        response = super().list(request, *args, **kwargs)
+        if ('project_type' in request.query_params and request.query_params['project_type'] == 'Powerplant'):
+            add_never_cache_headers(response)
+        return response
 
 class RegionListView(generics.ListAPIView):
     queryset = Region.objects.distinct().all()


### PR DESCRIPTION
* do not cache PP API calls so cache can be enabled which select2 requires
* Adjust the following env vars in the heroku dashboard as well:

```
DISABLE_CACHE = False
SELECT2_CACHE_BACKEND = default
```