### PR TITLE
Add docker support for auxiliary services

### DIFF
--- a/DETAILED_INSTRUCTIONS.md
+++ b/DETAILED_INSTRUCTIONS.md
@@ -133,6 +133,33 @@ $ sudo /bin/systemctl daemon-reload
 $ sudo /bin/systemctl enable elasticsearch.service
 ```
 
+## Docker setup
+
+Optionally, if preferred, you can use Docker to run several of the auxillary services, such as PostgreSQL, Memcached, and Elasticsearch. To do so, simply run:
+
+```sh
+docker-compose up -d
+```
+
+Update your ``.env`` file to point to the Docker containers:
+
+```sh
+DATABASE_URL=postgis://postgres@localhost:54321/postgres
+ELASTICSEARCH_URL=http://localhost:59200
+MEMCACHEIFY_USE_LOCAL=True
+DISABLE_CACHE=False
+MEMCACHE_SERVERS=localhost:11212
+```
+
+You can load a DB dump, if needed, into the container using:
+
+```sh
+dropdb -h localhost -p 54321 -U postgres postgres
+createdb -h localhost -p 54321 -U postgres postgres
+pg_restore -h localhost -p 54321 -U postgres -Ox -d postgres latest.dump
+```
+
+
 # Part 2: Setting up the website
 
 ## "Clone" the code repository

--- a/DETAILED_INSTRUCTIONS.md
+++ b/DETAILED_INSTRUCTIONS.md
@@ -148,7 +148,7 @@ DATABASE_URL=postgis://postgres@localhost:54321/postgres
 ELASTICSEARCH_URL=http://localhost:59200
 MEMCACHEIFY_USE_LOCAL=True
 DISABLE_CACHE=False
-MEMCACHE_SERVERS=localhost:11212
+MEMCACHE_SERVERS=localhost:51212
 ```
 
 You can load a DB dump, if needed, into the container using:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,11 @@ services:
     ports:
       - "59200:9200"
 
+  redis:
+    image: redis:4-alpine
+    ports:
+      - "56379:6379"
+
 volumes:
   pgdata:
   esdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+services:
+  db:
+    image: mdillon/postgis:9.4-alpine
+    environment:
+      PGDATABASE: postgres
+      PGUSER: postgres
+      PGHOST: db
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "54321:5432"
+
+  cache:
+    image: memcached:1.5-alpine
+    ports:
+      - "51212:11211"
+
+  elasticsearch:
+    image: elasticsearch:2.4-alpine
+    environment:
+      - discovery.type=single-node
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    ports:
+      - "59200:9200"
+
+volumes:
+  pgdata:
+  esdata:


### PR DESCRIPTION
Add Docker containers for running production-matching versions of PostgreSQL, Elasticsearch, etc. for local development testing.