### PR TITLE
Allow moving select2 to a different cache location

### DIFF
--- a/infrastructure/admin.py
+++ b/infrastructure/admin.py
@@ -163,6 +163,7 @@ class ProjectAdmin(PhraseSearchAdminMixin, admin.ModelAdmin):
         ProjectFundingInline
     ]
     raw_id_fields = ('power_plant', )
+    list_select_related = ('infrastructure_type', )
 
     def fieldbook_id(self, obj):
         if obj.extra_data.exists():

--- a/infrastructure/admin.py
+++ b/infrastructure/admin.py
@@ -162,6 +162,7 @@ class ProjectAdmin(PhraseSearchAdminMixin, admin.ModelAdmin):
     inlines = [
         ProjectFundingInline
     ]
+    raw_id_fields = ('power_plant', )
 
     def fieldbook_id(self, obj):
         if obj.extra_data.exists():

--- a/newsilkroad/settings.py
+++ b/newsilkroad/settings.py
@@ -232,6 +232,7 @@ DATABASES['default']['CONN_MAX_AGE'] = 500
 
 # Cache
 CACHE_DISABLED = os.getenv('DISABLE_CACHE', 'False') == 'True'
+SELECT2_CACHE_LOCATION = os.getenv('SELECT2_CACHE_LOCATION', '')
 
 if not CACHE_DISABLED:
     CACHES = memcacheify()
@@ -242,6 +243,17 @@ if not CACHE_DISABLED:
         'locations_pointgeometry',
         'locations_polygongeometry',
     ))
+    if SELECT2_CACHE_LOCATION:
+        CACHES['select2'] = {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": SELECT2_CACHE_LOCATION,
+            "TIMEOUT": 60 * 15,  # 15 minutes
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            }
+        }
+        # Set the cache backend to select2
+        SELECT2_CACHE_BACKEND = 'select2'
 else:
     CACHES = {
         'default': {

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ django-mptt==0.9.0
 django-picklefield==1.0.0
 django-polymorphic==2.0.2
 django-pylibmc==0.6.1
+django-redis==4.10.0
 django-reversion==2.0.13
 django-rq==1.1.0
 Django-Select2==6.0.2


### PR DESCRIPTION
After some initial testing (documented in RA-44), this PR moves the select2 cache to its own cache location, freeing it from potentially being clobbered in the primary cache. This is still a hunch, but here's what this attempts to fix:

* The site is heavily cached and always hovers around the max cache memory (100mb)
* django-select2 caches requests when the admin page loads
* On the production site, which is active, requests continue to be served/cached as users navigate the site
* Memcache runs out of memory, uses the LRU eviction process, and happens to purge the block of memory that select2 used
* select2 starts failing with a "key not found" error

By using a separate cache, this hopes to avoid that problem.

This is currently set to merge into the **master** branch, since this may be a hotfix.