### PR TITLE
Fix ProjectDocument admin loading issue

### DIFF
--- a/infrastructure/admin.py
+++ b/infrastructure/admin.py
@@ -16,6 +16,7 @@ from publish.admin import (
 from infrastructure.forms import (
     InitiativeForm,
     ProjectForm,
+    ProjectDocumentForm,
     ProjectFundingForm,
     PowerPlantForm,
     ProjectOwnerStakeForm
@@ -331,10 +332,16 @@ class ProjectDocumentAdmin(admin.ModelAdmin):
         'status_indicator',
     )
     list_filter = ('document_type', 'status_indicator')
-    search_fields = ('source_url', 'notes')
+    search_fields = ('source_url', 'notes', 'document__source_file__original_filename')
     inlines = [
         ProjectsDocumentsInline,
     ]
+    form = ProjectDocumentForm
+    list_select_related = ('document__source_file', )
+
+    def get_queryset(self, request):
+        # projects_display below iterates through obj.project_set.all(), so this'll cut down on SQL queries
+        return super().get_queryset(request).prefetch_related('project_set')
 
     def projects_display(self, obj):
         if obj.project_set:

--- a/infrastructure/forms.py
+++ b/infrastructure/forms.py
@@ -18,6 +18,8 @@ from locations.models import (
     Country,
     GeometryStore
 )
+from sources.forms import DocumentSearchField
+from sources.models import Document
 
 
 class MonthField(forms.IntegerField):
@@ -81,6 +83,18 @@ class ProjectSearchMultiField(forms.ModelMultipleChoiceField):
         kwargs['queryset'] = Project.objects.all()
         kwargs['help_text'] = 'Select field and begin typing to search'
         super().__init__(*args, **kwargs)
+
+
+class ProjectDocumentForm(forms.ModelForm):
+    document = DocumentSearchField(
+        required=False,
+        queryset=Document.objects.order_by('-id'),
+        help_text=DocumentSearchField.help_text
+    )
+
+    class Meta:
+        model = ProjectDocument
+        fields = '__all__'
 
 
 class ProjectDocumentSearchMultiWidget(ModelSelect2MultipleWidget):

--- a/sources/forms.py
+++ b/sources/forms.py
@@ -1,0 +1,19 @@
+from django import forms
+from django_select2.forms import (
+    ModelSelect2Widget,
+    ModelSelect2MultipleWidget,
+)
+from sources.models import Document
+
+
+class DocumentSearchWidget(ModelSelect2Widget):
+    model = Document
+    search_fields = [
+        'source_file__original_filename__icontains',
+        'url__icontains',
+    ]
+
+
+class DocumentSearchField(forms.ModelChoiceField):
+    widget = DocumentSearchWidget
+    help_text = "Select field and begin typing a document's name to search"


### PR DESCRIPTION
/admin/infrastructure/projectdocument/add/ failed to load on production because it was trying to render a 2k+ ``select`` field. To mimic the rest of the site, this PR implements a select2-style autocomplete for the Document model and adds it to the ProjectDocument admin.

Some other notes:
* The ProjectDocument admin list view generated a lot of SQL queries, so I added ``select_related`` and ``prefetch_related`` to reduce the number on page load
* I added ``sources/forms.py`` rather than ``sources/fields.py`` to mimic the project setup elsewhere