### PR TITLE
[RA-49] Display fuel category alongside fuel type on user-facing detail pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  db:
+    image: mdillon/postgis:9.4-alpine
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "54321:5432"
+
+  cache:
+    image: memcached:1.5-alpine
+    ports:
+      - "51212:11211"
+
+  elasticsearch:
+    image: elasticsearch:2.4-alpine
+    environment:
+      - discovery.type=single-node
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    ports:
+      - "59200:9200"
+
+  redis:
+    image: redis:4-alpine
+    ports:
+      - "56379:6379"
+
+volumes:
+  pgdata:
+  esdata:

--- a/infrastructure/templates/infrastructure/powerplant_detail.html
+++ b/infrastructure/templates/infrastructure/powerplant_detail.html
@@ -121,9 +121,11 @@
       <div class="row double">
           <section>
               <h3>Fuel Category</h3>
+                <ul class="clean">
                 {% for fuel in object.fuels.all %}
-                    <p>{{ fuel.fuel_category }}</p>
+                    <li>{{ fuel.fuel_category }}</li>
                 {% endfor %}
+                </ul>
           </section>
           <section>
               <h3>CO2 Emissions</h3>

--- a/infrastructure/templates/infrastructure/powerplant_detail.html
+++ b/infrastructure/templates/infrastructure/powerplant_detail.html
@@ -121,13 +121,9 @@
       <div class="row double">
           <section>
               <h3>Fuel Category</h3>
-              <div class="row double">
-                <section>
-                    {% for fuel in object.fuels.all %}
-                        <div> {{ fuel.fuel_category }}</div>
-                    {% endfor %}
-                </section>
-              </div>
+                {% for fuel in object.fuels.all %}
+                    <p>{{ fuel.fuel_category }}</p>
+                {% endfor %}
           </section>
           <section>
               <h3>CO2 Emissions</h3>

--- a/infrastructure/templates/infrastructure/powerplant_detail.html
+++ b/infrastructure/templates/infrastructure/powerplant_detail.html
@@ -120,16 +120,9 @@
       </div>
       <div class="row double">
           <section>
-              <h3>Fuel</h3>
+              <h3>Fuel Category</h3>
               <div class="row double">
                 <section>
-                    <h4> Fuel Type </h4>
-                    {% for fuel in object.fuels.all %}
-                        <div> {{ fuel }}</div>
-                    {% endfor %}
-                </section>
-                <section>
-                    <h4> Fuel Category </h4>
                     {% for fuel in object.fuels.all %}
                         <div> {{ fuel.fuel_category }}</div>
                     {% endfor %}

--- a/infrastructure/templates/infrastructure/powerplant_detail.html
+++ b/infrastructure/templates/infrastructure/powerplant_detail.html
@@ -122,8 +122,8 @@
           <section>
               <h3>Fuel Category</h3>
                 <ul class="clean">
-                {% for fuel in object.fuels.all %}
-                    <li>{{ fuel.fuel_category }}</li>
+                {% for fc in fuel_categories %}
+                    <li>{{ fc }}</li>
                 {% endfor %}
                 </ul>
           </section>

--- a/infrastructure/templates/infrastructure/powerplant_detail.html
+++ b/infrastructure/templates/infrastructure/powerplant_detail.html
@@ -121,9 +121,20 @@
       <div class="row double">
           <section>
               <h3>Fuel</h3>
-              {% for fuel in object.fuels.all %}
-                <div>{{ fuel }}</div>
-              {% endfor %}
+              <div class="row double">
+                <section>
+                    <h4> Fuel Type </h4>
+                    {% for fuel in object.fuels.all %}
+                        <div> {{ fuel }}</div>
+                    {% endfor %}
+                </section>
+                <section>
+                    <h4> Fuel Category </h4>
+                    {% for fuel in object.fuels.all %}
+                        <div> {{ fuel.fuel_category }}</div>
+                    {% endfor %}
+                </section>
+              </div>
           </section>
           <section>
               <h3>CO2 Emissions</h3>

--- a/infrastructure/templates/infrastructure/project_detail.html
+++ b/infrastructure/templates/infrastructure/project_detail.html
@@ -167,7 +167,6 @@
                             <li>{{ fuel }}</li>
                         {% endfor %}
                         </ul>
-                    </div>
                 </section>
           </div>
         </section>

--- a/infrastructure/templates/infrastructure/project_detail.html
+++ b/infrastructure/templates/infrastructure/project_detail.html
@@ -162,9 +162,11 @@
           <div class="row double">
                 <section>
                     <h3>Fuel Type</h3>
+                        <ul class="clean">
                         {% for fuel in object.fuels.all %}
-                            {{ fuel }}
+                            <li>{{ fuel }}</li>
                         {% endfor %}
+                        </ul>
                     </div>
                 </section>
           </div>

--- a/infrastructure/templates/infrastructure/project_detail.html
+++ b/infrastructure/templates/infrastructure/project_detail.html
@@ -163,7 +163,7 @@
                 <section>
                     <h3>Fuel Type</h3>
                         <ul class="clean">
-                        {% for fuel in object.fuels.all %}
+                        {% for fuel in fuel_types %}
                             <li>{{ fuel }}</li>
                         {% endfor %}
                         </ul>

--- a/infrastructure/templates/infrastructure/project_detail.html
+++ b/infrastructure/templates/infrastructure/project_detail.html
@@ -162,12 +162,9 @@
           <div class="row double">
                 <section>
                     <h3>Fuel Type</h3>
-                    <div class="row double">
-                        <section>
-                            {% for fuel in object.fuels.all %}
-                                <div> {{ fuel }}</div>
-                            {% endfor %}
-                        </section>
+                        {% for fuel in object.fuels.all %}
+                            {{ fuel }}
+                        {% endfor %}
                     </div>
                 </section>
           </div>

--- a/infrastructure/templates/infrastructure/project_detail.html
+++ b/infrastructure/templates/infrastructure/project_detail.html
@@ -160,12 +160,23 @@
               </section>
           </div>
           <div class="row double">
-              <section>
-                  <h3>Fuel</h3>
-                  {% for fuel in object.power_plant.fuels.all %}
-                    <div>{{ fuel }}</div>
-                  {% endfor %}
-              </section>
+                <section>
+                    <h3>Fuel</h3>
+                    <div class="row double">
+                        <section>
+                            <h4> Fuel Type </h4>
+                            {% for fuel in object.fuels.all %}
+                                <div> {{ fuel }}</div>
+                            {% endfor %}
+                        </section>
+                        <section>
+                            <h4> Fuel Category </h4>
+                            {% for fuel in object.fuels.all %}
+                                <div> {{ fuel.fuel_category }}</div>
+                            {% endfor %}
+                        </section>
+                    </div>
+                </section>
           </div>
         </section>
     {% endif %}

--- a/infrastructure/templates/infrastructure/project_detail.html
+++ b/infrastructure/templates/infrastructure/project_detail.html
@@ -161,18 +161,11 @@
           </div>
           <div class="row double">
                 <section>
-                    <h3>Fuel</h3>
+                    <h3>Fuel Type</h3>
                     <div class="row double">
                         <section>
-                            <h4> Fuel Type </h4>
                             {% for fuel in object.fuels.all %}
                                 <div> {{ fuel }}</div>
-                            {% endfor %}
-                        </section>
-                        <section>
-                            <h4> Fuel Category </h4>
-                            {% for fuel in object.fuels.all %}
-                                <div> {{ fuel.fuel_category }}</div>
                             {% endfor %}
                         </section>
                     </div>

--- a/infrastructure/views.py
+++ b/infrastructure/views.py
@@ -33,6 +33,7 @@ class ProjectDetailView(PublicationMixin, DetailView):
         context = super(ProjectDetailView, self).get_context_data(**kwargs)
         context['mapbox_token'] = MAPBOX_TOKEN
         context['mapbox_style'] = MAPBOX_STYLE_URL
+        context['fuel_types'] = self.object.fuels.all().distinct()
         return context
 
 
@@ -125,4 +126,5 @@ class PowerPlantDetailView(PublicationMixin, DetailView):
         context = super(PowerPlantDetailView, self).get_context_data(**kwargs)
         context['mapbox_token'] = MAPBOX_TOKEN
         context['mapbox_style'] = MAPBOX_STYLE_URL
+        context['fuel_categories'] = self.object.fuels.values_list('fuel_category__name', flat=True).distinct()
         return context


### PR DESCRIPTION
Modifies the template for Powerplants to display the category.  I looks like users of the site have been adding this information in as parentheses.  So until they change that it may look a little strange.

I added some styling to the template to add columns and labels so it is clearer what the data is. 