### PR TITLE
Update mapbox-gl requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "babel-polyfill": "^6.9.1",
     "classnames": "^2.2.6",
     "fetch": "^1.0.1",
-    "mapbox-gl": "^0.28.0",
+    "mapbox-gl": "^0.52.0",
     "object-merge": "^2.5.1",
     "promise-queue": "^2.2.3",
     "radium": "^0.18.1",


### PR DESCRIPTION
Weirdly enough:

- Updating this requirement does not induce any changes in the bundled JS that need to be committed
- It seems the result we were hoping for from upgrading this, namely map labels working on Firefox, is already there on staging

My guess is that although I *did* revert the changes to the repo that took place during my too-hasty push of the upgraded Mapbox GL code earlier, I did *not* restore a pre-upgrade state of `node_modules` locally after doing that, meaning that I was accidentally committing code that included the upgraded bundle whenever I committed the latest changes.

The upside is that there is basically nothing to verify in this PR. The bundles have not been changed, therefore the code is actually the same; this is just ratifying the existing state of the bundle by updating `package.json`.