### PR TITLE
[ra-125] get cache timeout from the environment if available

### DIFF
--- a/newsilkroad/settings.py
+++ b/newsilkroad/settings.py
@@ -528,3 +528,6 @@ if 'test' in sys.argv:
         }
     }
     SELECT2_CACHE_BACKEND = 'default'
+
+# set cache timeout from the environment
+CACHE_MIDDLEWARE_SECONDS = os.getenv('CACHE_MIDDLEWARE_SECONDS', 600)


### PR DESCRIPTION
This PR gets the CACHE_MIDDLEWARE_SECONDS setting from the environment if available.

To set this variable on staging, you have to do something like:

```
$ heroku config:set CACHE_MIDDLEWARE_SECONDS=1 --app csis-reconasia-bravo
```
This has already been done.