### PR TITLE
Fix bad sizing of infrastructure type toggle container

### DIFF
--- a/website/assets/sass/_searchview.scss
+++ b/website/assets/sass/_searchview.scss
@@ -12,6 +12,7 @@ $searchview-padding-y: 24px;
 $searchview-infrastructure-icon-size: 40px;
 $searchview-infrastructure-padding-left: 16px;
 $searchview-infrastructure-padding-right: 24px;
+$searchview-infrastructure-toggle-transition: 0.25s;
 
 $searchview-header-height: 50px;
 $searchview-heading-bottom-margin: $searchview-padding-y / 2;
@@ -398,7 +399,14 @@ button.searchView__update-results {
     z-index: 10;
     left: 290px;
     top: 70px;
-    width: auto;
+    max-width: $searchview-infrastructure-icon-size;
+    transition: all 0s;
+    transition-delay: $searchview-infrastructure-toggle-transition;
+
+    &:hover {
+        max-width: 100vw;
+        transition-delay: 0s;
+    }
 }
 
 .infrastructureIcon__container {
@@ -499,7 +507,7 @@ button.searchView__update-results {
 
     z-index: -1;
     transform: translateX(0);
-    transition: transform 0.25s;
+    transition: transform #{$searchview-infrastructure-toggle-transition};
 
     .infrastructureIcon__container:hover & {
         background-color: $map-infrastructure-hover-grey;
@@ -508,7 +516,7 @@ button.searchView__update-results {
 
 .infrastructureIcon__label--hidden {
     transform: translateX(-100%);
-    transition: transform 0.25s;
+    transition: transform #{$searchview-infrastructure-toggle-transition};
 }
 
 .infrastructureIcon__label--selected {


### PR DESCRIPTION
To see the problem, look at the map and hover your cursor in the space to the right of one of the infra type icons. You'll see it light up. Click it: you'll see it grey out & see the map update.

This is because the use of `transform` rather than some "real" position property results in the elements that have been moved out of view *not actually* being moved, simply being visually shifted; so they're still there and still clickable.

The easiest solution is to ensure that their overall container resizes appropriately on hover / non-hover so that they're not clickable when not in their hover state. To do this, we can use the old `max-width` transition trick (which emulates transitioning between `width: auto` and some known width).