### PR TITLE
Ra 156 humanize values

### DIFF
--- a/infrastructure/models.py
+++ b/infrastructure/models.py
@@ -413,6 +413,14 @@ class Project(Publishable):
         )
 
     @property
+    def humanize_capacity(self):
+        if self.project_capacity is None:
+            return False
+        if self.project_capacity > (1*10**6):
+            return True
+        return False
+
+    @property
     def pipeline_capacity_property(self):
         if self.project_capacity is None:
             return None

--- a/infrastructure/models.py
+++ b/infrastructure/models.py
@@ -416,7 +416,7 @@ class Project(Publishable):
     def humanize_capacity(self):
         if self.project_capacity is None:
             return False
-        if self.project_capacity >= (1*10**6):
+        if self.project_capacity >= (10**6):  # Is the capacity GTE to 1 million
             return True
         return False
 

--- a/infrastructure/models.py
+++ b/infrastructure/models.py
@@ -416,7 +416,7 @@ class Project(Publishable):
     def humanize_capacity(self):
         if self.project_capacity is None:
             return False
-        if self.project_capacity > (1*10**6):
+        if self.project_capacity >= (1*10**6):
             return True
         return False
 

--- a/infrastructure/templates/infrastructure/project_detail.html
+++ b/infrastructure/templates/infrastructure/project_detail.html
@@ -222,7 +222,11 @@
                   <section>
                      <h3>Capacity</h3>
                      <p>{% if object.project_capacity %}
-                        {{ object.project_capacity|intcomma}} {{ object.pipeline_capacity_property }}
+                        {%  if object.humanize_capacity %}
+                           {{ object.project_capacity|intword|intcomma}} {{ object.pipeline_capacity_property }}
+                        {% else %}
+                           {{ object.project_capacity|intcomma}} {{ object.pipeline_capacity_property }}
+                        {% endif %}
                      {% else %}
                         &mdash;
                      {% endif %}


### PR DESCRIPTION
After Neil’s excellent review on the original version of this ticket and talking with Gerald, we came to the conclusion that the cases we had set out for this were a little confusing and a little contradictory.

There seems to be no need to worry about decimal place if a number were to get as large as 1 million 1,000,000.78 seems to be a ludicrous precision on such a large number (we are not talking nuclear physics here).

So the best course of actions appears to be to allow values over 1 million to be humanized. I was wrong about the behavior of humanize; it appears that humanize does work on float values even though it’s code says it passes non-integers right through :shrug:), and values lower than one million to retain their decimals even though 999,999.78 is just as ludicrous a precision as 1,000,000.78.